### PR TITLE
Zones.htm - Added visual indication of disabled zones

### DIFF
--- a/web/Zones.htm
+++ b/web/Zones.htm
@@ -26,7 +26,8 @@
         function addZoneCtl(j, name, enabled, pump) {
           var zone_id = String.fromCharCode(97+j);
           var new_ctl = $('<div data-role="collapsible" data-collapsed="true">' +
-            '<h3>Zone ' + j + '</h3><label for="z' + zone_id + 'name">Name</label>' +
+            ((enabled == 'on') ? '<h3>Zone ' : '<h3 style="font-style:italic;">Zone ') + j +
+            ((enabled == 'on') ? '</h3>' : ' (Disabled)</h3>') + '<label for="z' + zone_id + 'name">Name</label>' +
             '<input name="z' + zone_id + 'name" id="z' + zone_id + 'name" placeholder="" value="' + name + '" type="text" maxlength=19/>' +
             '<fieldset data-role="controlgroup" data-type="vertical">' +
             '<input id="cb' + zone_id + 'e" name="z' + zone_id + 'e" type="checkbox" ' + ((enabled == 'on') ? 'checked="on"' : '') + '/>' +


### PR DESCRIPTION
Disabled zones are italicized and the label changed to "Zone x (Disabled)". This matches the style for disabled schedules.
