### PR TITLE
Chrome browser 405 error fix by increasing timeout

### DIFF
--- a/port.cpp
+++ b/port.cpp
@@ -224,7 +224,7 @@ int EthernetClient::read(uint8_t *buf, size_t size)
 	FD_ZERO(&sock_set);
 	FD_SET(m_sock, &sock_set);
 	struct timeval timeout;
-	timeout.tv_sec = 1;
+	timeout.tv_sec = 3;
 	timeout.tv_usec = 0;
 
 	select(m_sock + 1, &sock_set, NULL, NULL, &timeout);

--- a/web.cpp
+++ b/web.cpp
@@ -562,7 +562,7 @@ static bool ParseHTTPHeader(EthernetClient & client, KVPairs * key_value_pairs, 
 	key_value_pairs->num_pairs = 0;
 	char * key_ptr = key_value_pairs->keys[0];
 	char * value_ptr = key_value_pairs->values[0];
-	char recvbuf[100];  // note:  trial and error has shown that it doesn't help to increase this number.. few ms at the most.
+	char recvbuf[4*1024];  // note:  trial and error has shown that it doesn't help to increase this number.. few ms at the most.
 	char * recvbufptr = recvbuf;
 	char * recvbufend = recvbuf;
 	while (true)


### PR DESCRIPTION
This is my attempt to fix Chrome browser 405 error, it was described in forum post: https://opensprinkler.com/forums/topic/sprinklers_pi-an-alternative-sprinkler-control-program/page/13/#post-25104
So far works well on Chrome Windows and android versions.