### PR TITLE
Fix client disconnect

### DIFF
--- a/port.cpp
+++ b/port.cpp
@@ -224,7 +224,7 @@ int EthernetClient::read(uint8_t *buf, size_t size)
 	FD_ZERO(&sock_set);
 	FD_SET(m_sock, &sock_set);
 	struct timeval timeout;
-	timeout.tv_sec = 1;
+	timeout.tv_sec = 10;
 	timeout.tv_usec = 0;
 
 	select(m_sock + 1, &sock_set, NULL, NULL, &timeout);

--- a/sprinklers_pi.cpp
+++ b/sprinklers_pi.cpp
@@ -17,11 +17,17 @@ void signal_callback_handler(int signum)
    bTermSignal = true;
 }
 
+void signal_pipe_callback_handler(int signum)
+{
+   printf("Caught and ignored signal %d\n",signum);
+}
+
 int main(int argc, char **argv)
 {
 	// Register signal handlers
 	signal(SIGTERM, signal_callback_handler);
 	signal(SIGINT, signal_callback_handler);
+	signal(SIGPIPE, signal_pipe_callback_handler);
 
 	char * logfile = 0;
 	int c = -1;


### PR DESCRIPTION
This patch fixed my disconnection problem. I work with slow wireless network, and experienced many disconnections; this caused 2 things:

1. If the disconnection was during the time the server tries to write the info back - the server would receive a SIGPIPE and crash.
2. The client was disconnected if it took too long for the request to be sent to the server.

These patched solves them both.
