### PR TITLE
Adding in DNS resolution to Wunderground API calls.

### DIFF
--- a/Weather.cpp
+++ b/Weather.cpp
@@ -13,6 +13,7 @@
 
 Weather::Weather(void)
 {
+	 m_wundergroundAPIHost="api.wunderground.com";
 }
 
 static void ParseResponse(EthernetClient & client, Weather::ReturnVals * ret)
@@ -165,9 +166,9 @@ static void ParseResponse(EthernetClient & client, Weather::ReturnVals * ret)
 	} // while (true)
 }
 
-int Weather::GetScale(const IPAddress & ip, const char * key, uint32_t zip, const char * pws, bool usePws) const
+int Weather::GetScale(const char * key, uint32_t zip, const char * pws, bool usePws) const
 {
-	ReturnVals vals = GetVals(ip, key, zip, pws, usePws);
+	ReturnVals vals = GetVals(key, zip, pws, usePws);
 	return GetScale(vals);
 }
 
@@ -183,26 +184,30 @@ int Weather::GetScale(const ReturnVals & vals) const
 	return adj;
 }
 
-Weather::ReturnVals Weather::GetVals(const IPAddress & ip, const char * key, uint32_t zip, const char * pws, bool usePws) const
+Weather::ReturnVals Weather::GetVals(const char * key, uint32_t zip, const char * pws, bool usePws) const
 {
 	ReturnVals vals = {0};
 	EthernetClient client;
-	if (client.connect(ip, 80))
+	if (client.connect(m_wundergroundAPIHost, 80))
 	{
-		char getstring[90];
+		char getstring[255];
 		trace(F("Connected\n"));
 		if (usePws)
-			snprintf(getstring, sizeof(getstring), "GET /api/%s/yesterday/conditions/q/pws:%s.json HTTP/1.1\r\n", key, pws);
+			snprintf(getstring, sizeof(getstring), "GET http://%s/api/%s/yesterday/conditions/q/pws:%s.json HTTP/1.1\r\n",m_wundergroundAPIHost, key, pws);
 		else
-			snprintf(getstring, sizeof(getstring), "GET /api/%s/yesterday/conditions/q/%ld.json HTTP/1.1\r\n", key, (long) zip);
-		//trace(getstring);
-		client.write((uint8_t*) getstring, strlen(getstring));
-		//send host header
-		snprintf(getstring, sizeof(getstring), "Host: api.wunderground.com\r\nConnection: close\r\n\r\n");
-		client.write((uint8_t*) getstring, strlen(getstring));
+			snprintf(getstring, sizeof(getstring), "GET http://%s/api/%s/yesterday/conditions/q/%ld.json HTTP/1.1\r\n",m_wundergroundAPIHost, key, (long) zip);
 
+		//trace("GetString:%s\n",getstring);
+		client.write((uint8_t*) getstring, strlen(getstring));
+		
+		//send host header
+		snprintf(getstring, sizeof(getstring), "Host: %s\r\nConnection: close\r\n\r\n",m_wundergroundAPIHost);
+		//trace("GetString:%s\n",getstring);
+		client.write((uint8_t*) getstring, strlen(getstring));
 
 		ParseResponse(client, &vals);
+		vals.resolvedIP=client.GetIpAddress();
+
 		client.stop();
 		if (!vals.valid)
 		{

--- a/Weather.h
+++ b/Weather.h
@@ -24,12 +24,15 @@ public:
 		short precipi;
 		short windmph;
 		short UV;
+		const char* resolvedIP;
 	};
 public:
 	Weather(void);
-	int GetScale(const IPAddress & ip, const char * key, uint32_t zip, const char * pws, bool usePws) const;
+	int GetScale(const char * key, uint32_t zip, const char * pws, bool usePws) const;
 	int GetScale(const ReturnVals & vals) const;
-	ReturnVals GetVals(const IPAddress & ip, const char * key, uint32_t zip, const char * pws, bool usePws) const;
+	ReturnVals GetVals(const char * key, uint32_t zip, const char * pws, bool usePws) const;
+private:
+	const char* m_wundergroundAPIHost;
 };
 
 #endif

--- a/core.cpp
+++ b/core.cpp
@@ -224,7 +224,7 @@ static runStateClass::DurationAdjustments AdjustDurations(Schedule * sched)
 		GetApiKey(key);
 		char pws[12] = {0};
 		GetPWS(pws);
-		adj.wunderground = w.GetScale(GetWUIP(), key, GetZip(), pws, GetUsePWS());   // factor to adjust times by.  100 = 100% (i.e. no adjustment)
+		adj.wunderground = w.GetScale(key, GetZip(), pws, GetUsePWS());   // factor to adjust times by.  100 = 100% (i.e. no adjustment)
 	}
 	adj.seasonal = GetSeasonalAdjust();
 	long scale = ((long)adj.seasonal * (long)adj.wunderground) / 100;

--- a/port.cpp
+++ b/port.cpp
@@ -15,7 +15,9 @@
 #include <netinet/in.h>
 #include <string.h>
 #include <errno.h>
-
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <netdb.h>
 void trace(const char * fmt, ...)
 {
 	time_t curTime = time(0);
@@ -188,7 +190,36 @@ int EthernetClient::connect(IPAddress ip, uint16_t port)
 	m_connected = true;
 	return 1;
 }
+int EthernetClient::connect(const char* host, uint16_t port)
+{
+	if (m_sock)
+		return 0;
+	trace("Trying to connect to:%s\n", host);
 
+	hostent * resolvedHost = gethostbyname(host);
+	if(resolvedHost == NULL)
+	{
+		trace("Error resolving %s (%d)%s\n",host, errno, strerror(errno));
+	}
+	
+	in_addr * actualIP = (in_addr * )resolvedHost->h_addr;
+	char* chIpAddress = inet_ntoa(* actualIP);
+	m_ipAddress=chIpAddress;
+	trace("Resolved %s to:%s\n",host, chIpAddress);
+
+	struct sockaddr_in sin = {0};
+	sin.sin_family = AF_INET;
+	sin.sin_port = htons(port);
+	sin.sin_addr=*actualIP;
+	m_sock = socket(AF_INET, SOCK_STREAM, 0);
+	if (::connect(m_sock, (struct sockaddr *) &sin, sizeof(sin)) < 0)
+	{
+		trace("Error Connecting(%d)%s\n", errno, strerror(errno));
+		return false;
+	}
+	m_connected = true;
+	return 1;
+}
 bool EthernetClient::connected()
 {
 	if (!m_sock)

--- a/port.h
+++ b/port.h
@@ -154,6 +154,7 @@ public:
 	EthernetClient(int sock);
 	~EthernetClient();
 	int connect(IPAddress ip, uint16_t port);
+	int connect(const char* host, uint16_t port);
 	bool connected();
 	void stop();
 	int read(uint8_t *buf, size_t size);
@@ -163,7 +164,12 @@ public:
 	{
 		return m_sock;
 	}
+	char* GetIpAddress()
+	{
+		return m_ipAddress;
+	}
 private:
+	char* m_ipAddress;
 	int m_sock;
 	bool m_connected;
 	friend class EthernetServer;

--- a/web.cpp
+++ b/web.cpp
@@ -232,12 +232,13 @@ static void JSONwCheck(const KVPairs & key_value_pairs, FILE * stream_file)
 	GetApiKey(key);
 	char pws[12] = {0};
 	GetPWS(pws);
-	const Weather::ReturnVals vals = w.GetVals(GetWUIP(), key, GetZip(), pws, GetUsePWS());
+	const Weather::ReturnVals vals = w.GetVals(key, GetZip(), pws, GetUsePWS());
 	const int scale = w.GetScale(vals);
 
 	fprintf(stream_file, "{\n");
 	fprintf_P(stream_file, PSTR("\t\"valid\" : \"%s\",\n"), vals.valid ? "true" : "false");
 	fprintf_P(stream_file, PSTR("\t\"keynotfound\" : \"%s\",\n"), vals.keynotfound ? "true" : "false");
+	fprintf_P(stream_file, PSTR("\t\"resolvedIP\" : \"%s\",\n"), vals.resolvedIP);
 	fprintf_P(stream_file, PSTR("\t\"minhumidity\" : \"%d\",\n"), vals.minhumidity);
 	fprintf_P(stream_file, PSTR("\t\"maxhumidity\" : \"%d\",\n"), vals.maxhumidity);
 	fprintf_P(stream_file, PSTR("\t\"meantempi\" : \"%d\",\n"), vals.meantempi);

--- a/web/Settings.htm
+++ b/web/Settings.htm
@@ -79,10 +79,6 @@
             <label for="gateway">Gateway:</label>
             <input type="text" name="gateway" id="gateway" value="" maxlength=15 />
           </div>
-          <div id="wuipdiv" data-role="fieldcontain">
-            <label for="wuip">WUndgerground IP:</label>
-            <input type="text" name="wuip" id="wuip" value="" maxlength=15 />
-          </div>
           <div id="apikeydiv" data-role="fieldcontain">
             <label for="apikey">API Key:</label>
             <input type="text" name="apikey" id="apikey" value="" maxlength=16 />

--- a/web/WCheck.htm
+++ b/web/WCheck.htm
@@ -21,7 +21,8 @@
             } else if (data.valid == "false") {
               $('#wuText').empty().append("Invalid Response from WUnderground server!");
             } else {
-              $('#wuText').empty().append("Min Humidity: " + data.minhumidity + "%");
+              $('#wuText').empty().append("Resolved WUnderground IP: " + data.resolvedIP);
+              $('#wuText').append("<br/>Min Humidity: " + data.minhumidity + "%");
               $('#wuText').append("<br/>Max Humidity: " + data.maxhumidity + "%");
               $('#wuText').append("<br/>Mean Temp: " + data.meantempi + "&deg;F");
               $('#wuText').append("<br/>Precip Today: " + data.precip_today/100 + "\"");


### PR DESCRIPTION
Hello. I added DNS resolution to the WUnderground calls. Its been awhile since I wrote C++, so please forgive me if I have any bugs or naming convention issues. This was tested on a Raspberry PI Zero W. 

I made the following edits. Any feedback would be appreciated.
-Added in calls to gethostbyname for DNS resolution.
-Removed input for WUnderground IP in UI.
-Added resolved IP to UI on WCheck page.
-Added property to Port.h so I can access resolved IP for above.
-Removed usages of IP where not needed.
-Added full url to API calls as per spec for HTTP
GET(https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html)